### PR TITLE
Add exception details when exceptions happen

### DIFF
--- a/FOIYL.py
+++ b/FOIYL.py
@@ -89,8 +89,8 @@ def menu(input='nothing',stage='0'):
             app_choice = int(con)
             target_app = app_choices[app_choice]
             menu(target_app,"2")
-        except:
-            print "Invalid Entry."
+        except Exception as e:
+            print "Invalid Entry: {0}".format(e)
             sys.exit(1)
         ###################################################################
         #Stage 2
@@ -103,8 +103,8 @@ def menu(input='nothing',stage='0'):
         try:
             print predefine_osa[choice]
             os.system("echo "+predefine_osa[choice])
-        except:
-            print "Error"
+        except Exception as e:
+            print "Error: {0}".format(e)
     elif stage=="2":
         print "--Enter text you want to prompt the user with, press enter for a generic prompt--"
         dialog1 = raw_input(">> ")


### PR DESCRIPTION
Basic change to include more details when errors occur

```
dpopes@dpopes:~/scratch/FiveOnceInYourLife (master) [18:13:07] ✓
$ python FOIYL.py
[1]: Define Application.
[2]: Pick Local Application from /Applications/.
[3]: Use predefined script.
>> 3
--Enter number for osascript you want to use--
>> 1
Error
dpopes@dpopes:~/scratch/FiveOnceInYourLife (master) [18:13:12] ✓
$ git checkout add_exception_details
Switched to branch 'add_exception_details'
Your branch is ahead of 'origin/master' by 1 commit.
  (use "git push" to publish your local commits)
dpopes@dpopes:~/scratch/FiveOnceInYourLife (add_exception_details) [18:13:21] ✓
$ python FOIYL.py
[1]: Define Application.
[2]: Pick Local Application from /Applications/.
[3]: Use predefined script.
>> 3
--Enter number for osascript you want to use--
>> 1
Error: list indices must be integers, not str
```

This doesn't fix that underlying error / mistake of indexing by string vs index, but it surfaces the actual error.